### PR TITLE
Bug fix: use "Fixnum" instead of "FixNum"

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -329,7 +329,7 @@ puts greeting
 1.class
 "Hello".class
 "Hello".kind_of?(String)
-1.kind_of?(FixNum)
+1.kind_of?(Fixnum)
 2.kind_of?(String)
 
 						</code></pre>


### PR DESCRIPTION
1.kind_of?(FixNum) returns

``` ruby
irb(main):005:0> 1.kind_of?(FixNum)
NameError: uninitialized constant FixNum
    from (irb):5
    from /Users/stevesmith/.rbenv/versions/2.0.0-p481/bin/irb:12:in `<main>'
```

1.kind_of?(Fixnum) returns

``` ruby
irb(main):013:0> 1.kind_of?(Fixnum)
=> true
```
